### PR TITLE
Infra-5842-Removed--rm-dist flag from publish.sh

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 before:

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -22,7 +22,7 @@ git tag "$VERSION"
 git push origin "$VERSION"
 
 # Run goreleaser to generate binaries and publish release
-goreleaser release
+goreleaser release --clean
 
 # Upload to GCS
 if [ ! -d "dist" ]; then

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -22,7 +22,7 @@ git tag "$VERSION"
 git push origin "$VERSION"
 
 # Run goreleaser to generate binaries and publish release
-goreleaser release --rm-dist
+goreleaser release
 
 # Upload to GCS
 if [ ! -d "dist" ]; then


### PR DESCRIPTION
For terraform-provider-chef we need to update publish.sh to remove the --rm-dist flag
Since the project is now on Go 1.26, GoReleaser v1 is no longer compatible. --rm-dist is a v1‑specific/deprecated flag.